### PR TITLE
Fix: Only 4 character overlap where ever evaluated.

### DIFF
--- a/Ordgåter/Program.cs
+++ b/Ordgåter/Program.cs
@@ -43,9 +43,9 @@ namespace Ordgåter
 
         private static bool IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(string word1, string word2)
         {
-            return IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(5, word1, word2)
+            return IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(3, word1, word2)
                 || IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(4, word1, word2)
-                || IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(3, word1, word2);
+                || IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(5, word1, word2);
         }
 
         private static bool IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(int commonLength, string word1, string word2)

--- a/Ordgåter/Program.cs
+++ b/Ordgåter/Program.cs
@@ -43,8 +43,9 @@ namespace Ordgåter
 
         private static bool IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(string word1, string word2)
         {
-            return IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(4, word1, word2)
-            || IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(5, word1, word2);
+            return IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(5, word1, word2)
+                || IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(4, word1, word2)
+                || IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(3, word1, word2);
         }
 
         private static bool IsLastPartOfFirstWordEqualToFirstPartOfSecondWord(int commonLength, string word1, string word2)


### PR DESCRIPTION
5 character overlap where never evaluated because 4 was evaulated first, meaning that if false it would be false for 5 as well. Also, added evaluation for 3 characters as well.